### PR TITLE
Update netspeed.py

### DIFF
--- a/netspeed.py
+++ b/netspeed.py
@@ -17,7 +17,7 @@ class NetSpeed(object):
 
     def parse_info(self, html):
         def clean_html(html):
-            soup = BeautifulSoup(html)
+            soup = BeautifulSoup(html, "html.parser")
             result = soup.find(id="webcode").string
 
             # Remove unexcepted ";" under OS X.


### PR DESCRIPTION
python3 main_cli.py info

/usr/local/lib/python3.5/site-packages/bs4/**init**.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")

  markup_type=markup_type))
SpeedUp: False
Normal speed: 20 Mbps
Speedup speed: 100 Mbps
Left time: 4.0h
